### PR TITLE
Make build.sh executable via post-action

### DIFF
--- a/Content/.template.config/template.json
+++ b/Content/.template.config/template.json
@@ -9,5 +9,15 @@
   },
   "identity": "Saturn.Template",
   "shortName": "Saturn",
-  "sourceName": "SaturnServer"
+  "sourceName": "SaturnServer",
+  "postActions": [{
+      "condition": "(OS != \"windows\")",
+      "description": "Make scripts executable",
+      "manualInstructions": [ { "text": "Run 'chmod +x *.sh'" } ],
+      "actionId": "cb9a6cf3-4f5c-4860-b9d2-03a574959774",
+      "args": {
+              "+x": "*.sh"
+          },
+      "continueOnError": true
+  }]
 }


### PR DESCRIPTION
See https://github.com/dotnet/templating/wiki/Post-Action-Registry#change-file-permissions for details. This should fix https://github.com/SaturnFramework/Saturn/issues/15.