### PR TITLE
Ensure Unix-only post-action won't run on Windows

### DIFF
--- a/Content/.template.config/template.json
+++ b/Content/.template.config/template.json
@@ -11,7 +11,7 @@
   "shortName": "Saturn",
   "sourceName": "SaturnServer",
   "postActions": [{
-      "condition": "(OS != \"windows\")",
+      "condition": "(OS != \"Windows_NT\")",
       "description": "Make scripts executable",
       "manualInstructions": [ { "text": "Run 'chmod +x *.sh'" } ],
       "actionId": "cb9a6cf3-4f5c-4860-b9d2-03a574959774",


### PR DESCRIPTION
The value of the OS environment variable on Windows isn't "windows" these days, it's "Windows_NT". So the current template.json would make the template fail to install correctly on a Windows machine; this PR should fix that. See SAFE-Stack/SAFE-template#36 for more.