### PR TITLE
Increase version for Migrations to 3.1 as well

### DIFF
--- a/Content/src/Migrations/Migrations.fsproj
+++ b/Content/src/Migrations/Migrations.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
 


### PR DESCRIPTION
"dotnet saturn migration" fails due to incompatible netcoreapp version in Migrations project.

Getting started guide will fail at this step for newbies.