### PR TITLE
global.json: support indicated version or newer

### DIFF
--- a/Content/global.json
+++ b/Content/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.301"
+    "version": "3.1.301",
+    "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
# Changes

`global.json` is currently the following:

```
{
  "sdk": {
    "version": "3.1.301"
  }
}
```

This means that only .NET SDK version `3.1.301` can be used.

This patch changes `global.json` to the following:

```
{
  "sdk": {
    "version": "3.1.301",
    "rollForward": "latestMajor"
  }
}
```

This means that `3.1.301` *or later* can be used.

# Alternatives

The documentation for `global.json` states the following:

> In general, you want to use the latest version of the SDK tools, so no global.json file is needed.

So technically, we could get away with simply removing `global.json`. I've stuck with the more conservative approach and left the minimum version requirement in.

# Earlier versions?

We may want to change the version to something earlier than `3.1.301` if an earlier one is sufficient.

# References

[Documentation for global.json](https://docs.microsoft.com/en-us/dotnet/core/tools/global-json?tabs=netcore3x)

[Documentation for rollForward](https://docs.microsoft.com/en-us/dotnet/core/tools/global-json?tabs=netcore3x#rollforward)