### PR TITLE
Content/build.fsx: use CreateProcess

### DIFF
--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -6,6 +6,8 @@ open Fake.DotNet
 open Fake.IO
 open System.Threading
 
+open System.Runtime.InteropServices
+
 let appPath = "./src/SaturnServer/" |> Path.getFullName
 let projectPath = Path.combine appPath "SaturnServer.fsproj"
 
@@ -27,7 +29,13 @@ Target.create "Run" (fun _ ->
   }
   let browser = async {
     Thread.Sleep 5000
-    Process.start (fun i -> { i with FileName = "http://localhost:8085" }) |> ignore
+
+    if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
+      CreateProcess.fromRawCommand "cmd.exe" [ "/C"; "start http://localhost:8085" ] |> Proc.run |> ignore
+    elif RuntimeInformation.IsOSPlatform(OSPlatform.Linux) then
+      CreateProcess.fromRawCommand "xdg-open" [ "http://localhost:8085" ] |> Proc.run |> ignore
+    elif RuntimeInformation.IsOSPlatform(OSPlatform.OSX) then
+      CreateProcess.fromRawCommand "open" [ "http://localhost:8085" ] |> Proc.run |> ignore
   }
 
   [ server; browser]


### PR DESCRIPTION
# Summary of changes

Use CreateProcess instead of Process.start

# Issue

If I go through the "How to start" guide for Saturn:

https://saturnframework.org/tutorials/how-to-start.html

when I run the last step:

    dotnet fake build -t run

the webserver does indeed appear to start. I can go to http://localhost:8085/books and see the resulting application.

However, if I ctrl-c at the console to stop the webserver, I notice the following:

![image](https://user-images.githubusercontent.com/20816/107861165-c804b200-6df8-11eb-96c3-8c86f0cf8097.png)

On Windows, the browser is never launched.

# Changes

The following line:

```fsharp
    Process.start (fun i -> { i with FileName = "http://localhost:8085" }) |> ignore
```

was replaced with the following:

```fsharp
    if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
      CreateProcess.fromRawCommand "cmd.exe" [ "/C"; "start http://localhost:8085" ] |> Proc.run |> ignore
    elif RuntimeInformation.IsOSPlatform(OSPlatform.Linux) then
      CreateProcess.fromRawCommand "xdg-open" [ "http://localhost:8085" ] |> Proc.run |> ignore
    elif RuntimeInformation.IsOSPlatform(OSPlatform.OSX) then
      CreateProcess.fromRawCommand "open" [ "http://localhost:8085" ] |> Proc.run |> ignore
```

# Notes

Some discussion of the issue on stackoverflow:

https://stackoverflow.com/questions/66139159/process-start-being-used-to-launch-browser-but-is-now-deprecated

Thanks to user `nh2` who made the suggestion to take a look at how Plotly.NET launches browsers:

https://stackoverflow.com/a/66184603/268581