### PR TITLE
Updated sourceName to support kebab-case names

### DIFF
--- a/Content/.template.config/template.json
+++ b/Content/.template.config/template.json
@@ -9,5 +9,5 @@
   },
   "identity": "Saturn.Template",
   "shortName": "Saturn",
-  "sourceName": "SaturnServer"
+  "sourceName": "SaturnServer.1"
 }

--- a/Content/SaturnServer.sln
+++ b/Content/SaturnServer.sln
@@ -4,7 +4,7 @@ VisualStudioVersion = 15.0.27004.2009
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2364C03F-7BCF-4E5A-9720-95991959E582}"
 EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "SaturnServer", "src\SaturnServer\SaturnServer.fsproj", "{EF178058-7006-4ED9-8268-912C3638A81C}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "SaturnServer.1", "src\SaturnServer.1\SaturnServer.1.fsproj", "{EF178058-7006-4ED9-8268-912C3638A81C}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Migrations", "src\Migrations\Migrations.fsproj", "{99166CAE-99E9-4F34-A421-48C69C84CB4C}"
 EndProject

--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -8,8 +8,8 @@ open System.Threading
 
 open System.Runtime.InteropServices
 
-let appPath = "./src/SaturnServer/" |> Path.getFullName
-let projectPath = Path.combine appPath "SaturnServer.fsproj"
+let appPath = "./src/SaturnServer.1/" |> Path.getFullName
+let projectPath = Path.combine appPath "SaturnServer.1.fsproj"
 
 
 Target.create "Clean" ignore

--- a/Content/src/Migrations/Program.fs
+++ b/Content/src/Migrations/Program.fs
@@ -10,7 +10,7 @@ open SimpleMigrations.Console
 [<EntryPoint>]
 let main argv =
     let assembly = Assembly.GetExecutingAssembly()
-    use db = new SqliteConnection "DataSource=src/SaturnServer/database.sqlite"
+    use db = new SqliteConnection "DataSource=src/SaturnServer.1/database.sqlite"
     let provider = SqliteDatabaseProvider(db)
     let migrator = SimpleMigrator(assembly, provider)
     let consoleRunner = ConsoleRunner(migrator)

--- a/Content/src/SaturnServer/Templates/App.fs
+++ b/Content/src/SaturnServer/Templates/App.fs
@@ -7,7 +7,7 @@ let layout (content: XmlNode list) =
         head [] [
             meta [_charset "utf-8"]
             meta [_name "viewport"; _content "width=device-width, initial-scale=1" ]
-            title [] [encodedText "Hello SaturnServer"]
+            title [] [encodedText "Hello SaturnServer.1"]
             link [_rel "stylesheet"; _href "https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" ]
             link [_rel "stylesheet"; _href "https://cdnjs.cloudflare.com/ajax/libs/bulma/0.6.1/css/bulma.min.css" ]
             link [_rel "stylesheet"; _href "/app.css" ]

--- a/Content/src/SaturnServer/Templates/InternalError.fs
+++ b/Content/src/SaturnServer/Templates/InternalError.fs
@@ -7,7 +7,7 @@ let layout (ex: Exception) =
         head [] [
             meta [_charset "utf-8"]
             meta [_name "viewport"; _content "width=device-width, initial-scale=1" ]
-            title [] [encodedText "SaturnServer - Error #500"]
+            title [] [encodedText "SaturnServer.1 - Error #500"]
         ]
         body [] [
            h1 [] [rawText "ERROR #500"]

--- a/Content/src/SaturnServer/Templates/NotFound.fs
+++ b/Content/src/SaturnServer/Templates/NotFound.fs
@@ -7,7 +7,7 @@ let layout =
         head [] [
             meta [_charset "utf-8"]
             meta [_name "viewport"; _content "width=device-width, initial-scale=1" ]
-            title [] [encodedText "SaturnServer - Error #404"]
+            title [] [encodedText "SaturnServer.1 - Error #404"]
         ]
         body [] [
            h1 [] [rawText "ERROR #404"]


### PR DESCRIPTION
This change should fix #9 .
[The root cause](https://github.com/dotnet/templating/issues/1168) of the issue seems to be .net template engine which generates variants based on the name, but is unable to figure out which variant where should be used. 
Unfortunately I wasn't able to build/run generated project, since it's still on .NET Core 3 and I got only .NET 6 atm, but I was able to check that with this change both kebab-case and snake_case are properly replaced.
